### PR TITLE
MudRTLProvider: Named the RightToLeft CascadingValue since it can interfere with user's code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,9 +38,9 @@ For example:
 
 ### Pull Requests which introduce new components
 - MudBlazor supports RTL. It basically mirrors the ui horizontally for languages which are read right-to-left. See [RTL guide](https://rtlstyling.com/posts/rtl-styling)  for more information. Therefore every component should implement this functionality.
-If necessary include
+If necessary include (make sure to use the `Name` property, it must be `"RightToLeft"`, use nameof if possible to allow for easier refactoring if ever needed. `nameof(RightToLeft)` can be refactored using F2 on Visual Studio (if ever needed), `Name = "RightToLeft"` cannot).
 ```csharp
-[CascadingParameter] public bool RightToLeft {get; set;}
+[CascadingParameter(Name = nameof(RightToLeft))] public bool RightToLeft {get; set;}
 ```
 in your component and apply styles at component level.
 - You must add tests if your component contains any logic (CSS styling requires no testing)

--- a/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
@@ -1167,7 +1167,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<SimpleColorPickerTest>(p =>
             {
-                p.AddCascadingValue(true);
+                p.AddCascadingValue("RightToLeft", true);
             });
 
             //Console.WriteLine(comp.Markup);

--- a/src/MudBlazor.UnitTests/Components/TimelineTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimelineTests.cs
@@ -103,7 +103,7 @@ namespace MudBlazor.UnitTests.Components
 
         public void TimelineTest_Position(TimelineOrientation orientation, TimelinePosition position, bool rtl, string[] expectedClass)
         {
-            var comp = Context.RenderComponent<TimelineTest>(p => p.AddCascadingValue(rtl));
+            var comp = Context.RenderComponent<TimelineTest>(p => p.AddCascadingValue("RightToLeft", rtl));
             //Console.WriteLine(comp.Markup);
 
             var timeline = comp.FindComponent<MudTimeline>();

--- a/src/MudBlazor/Components/Alert/MudAlert.razor.cs
+++ b/src/MudBlazor/Components/Alert/MudAlert.razor.cs
@@ -35,7 +35,7 @@ namespace MudBlazor
             };
         }
 
-        [CascadingParameter] public bool RightToLeft { get; set; }
+        [CascadingParameter(Name = nameof(RightToLeft))] public bool RightToLeft { get; set; }
 
         /// <summary>
         /// Sets the position of the text to the start (Left in LTR and right in RTL).

--- a/src/MudBlazor/Components/ButtonGroup/MudButtonGroup.razor.cs
+++ b/src/MudBlazor/Components/ButtonGroup/MudButtonGroup.razor.cs
@@ -20,7 +20,7 @@ namespace MudBlazor
         .Build();
 
 
-        [CascadingParameter] public bool RightToLeft { get; set; }
+        [CascadingParameter(Name = nameof(RightToLeft))] public bool RightToLeft { get; set; }
 
         /// <summary>
         /// If true, the button group will override the styles of the individual buttons.

--- a/src/MudBlazor/Components/Carousel/MudCarousel.razor.cs
+++ b/src/MudBlazor/Components/Carousel/MudCarousel.razor.cs
@@ -46,7 +46,7 @@ namespace MudBlazor
             };
         }
 
-        [CascadingParameter] public bool RightToLeft { get; set; }
+        [CascadingParameter(Name = nameof(RightToLeft))] public bool RightToLeft { get; set; }
 
 
         /// <summary>

--- a/src/MudBlazor/Components/Carousel/MudCarouselItem.razor.cs
+++ b/src/MudBlazor/Components/Carousel/MudCarouselItem.razor.cs
@@ -42,7 +42,7 @@ namespace MudBlazor
 
         [CascadingParameter] protected internal MudBaseItemsControl<MudCarouselItem> Parent { get; set; }
 
-        [CascadingParameter] public bool RightToLeft { get; set; }
+        [CascadingParameter(Name = nameof(RightToLeft))] public bool RightToLeft { get; set; }
 
         /// <summary>
         /// The color of the component. It supports the theme colors.

--- a/src/MudBlazor/Components/Chart/MudChart.razor.cs
+++ b/src/MudBlazor/Components/Chart/MudChart.razor.cs
@@ -43,7 +43,7 @@ namespace MudBlazor
           .AddClass(Class)
         .Build();
 
-        [CascadingParameter]
+        [CascadingParameter(Name = nameof(RightToLeft))]
         public bool RightToLeft { get; set; }
 
         /// <summary>

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -59,7 +59,7 @@ namespace MudBlazor
 
         #region Parameters
 
-        [CascadingParameter] public bool RightToLeft { get; set; }
+        [CascadingParameter(Name = nameof(RightToLeft))] public bool RightToLeft { get; set; }
 
         private bool _disableAlpha = false;
 

--- a/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogInstance.razor.cs
@@ -19,7 +19,7 @@ namespace MudBlazor
 
         [Inject] private IKeyInterceptorFactory _keyInterceptorFactory { get; set; }
 
-        [CascadingParameter] public bool RightToLeft { get; set; }
+        [CascadingParameter(Name = nameof(RightToLeft))] public bool RightToLeft { get; set; }
         [CascadingParameter] private MudDialogProvider Parent { get; set; }
         [CascadingParameter] private DialogOptions GlobalDialogOptions { get; set; } = new DialogOptions();
 

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -68,7 +68,7 @@ namespace MudBlazor
 
         [CascadingParameter] MudDrawerContainer DrawerContainer { get; set; }
 
-        [CascadingParameter]
+        [CascadingParameter(Name = nameof(RightToLeft))]
         bool RightToLeft
         {
             get => _rtl;

--- a/src/MudBlazor/Components/Drawer/MudDrawerContainer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawerContainer.razor.cs
@@ -27,7 +27,7 @@ namespace MudBlazor
             .AddStyle(Style)
         .Build();
 
-        [CascadingParameter]
+        [CascadingParameter(Name = nameof(RightToLeft))]
         public bool RightToLeft { get; set; }
 
         [Parameter]

--- a/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
+++ b/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
@@ -230,7 +230,8 @@ namespace MudBlazor
         [Category(CategoryTypes.Pagination.Appearance)]
         public string LastIcon { get; set; } = Icons.Material.Filled.LastPage;
 
-        [CascadingParameter] public bool RightToLeft { get; set; }
+        [CascadingParameter(Name = nameof(RightToLeft))] 
+        public bool RightToLeft { get; set; }
 
         #endregion
 

--- a/src/MudBlazor/Components/Popover/MudPopover.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopover.razor.cs
@@ -45,7 +45,7 @@ namespace MudBlazor
             };
         }
 
-        [CascadingParameter] public bool RightToLeft { get; set; }
+        [CascadingParameter(Name = nameof(RightToLeft))] public bool RightToLeft { get; set; }
 
         /// <summary>
         /// Sets the maxheight the popover can have when open.

--- a/src/MudBlazor/Components/RTLProvider/MudRTLProvider.razor
+++ b/src/MudBlazor/Components/RTLProvider/MudRTLProvider.razor
@@ -2,7 +2,7 @@
 @inherits MudComponentBase
 
 <MudElement HtmlTag="div" Class="@Classname" Style="@Style" UserAttributes="@UserAttributes" Tag="@Tag">
-    <CascadingValue Value="@RightToLeft">
+    <CascadingValue Value="@RightToLeft" Name="@nameof(RightToLeft)">
         @ChildContent
     </CascadingValue>
 </MudElement>

--- a/src/MudBlazor/Components/Radio/MudRadio.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor.cs
@@ -10,7 +10,7 @@ namespace MudBlazor
 {
     public partial class MudRadio<T> : MudComponentBase, IDisposable
     {
-        [CascadingParameter] public bool RightToLeft { get; set; }
+        [CascadingParameter(Name = nameof(RightToLeft))] public bool RightToLeft { get; set; }
 
         protected string Classname =>
         new CssBuilder("mud-radio")

--- a/src/MudBlazor/Components/Snackbar/MudSnackbarProvider.razor.cs
+++ b/src/MudBlazor/Components/Snackbar/MudSnackbarProvider.razor.cs
@@ -14,7 +14,7 @@ namespace MudBlazor
     {
         [Inject] private ISnackbar Snackbars { get; set; }
 
-        [CascadingParameter] public bool RightToLeft { get; set; }
+        [CascadingParameter(Name = nameof(RightToLeft))] public bool RightToLeft { get; set; }
 
         protected IEnumerable<Snackbar> Snackbar => Snackbars.Configuration.NewestOnTop
                 ? Snackbars.ShownSnackbars.Reverse()

--- a/src/MudBlazor/Components/Table/MudTablePager.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTablePager.razor.cs
@@ -21,7 +21,7 @@ namespace MudBlazor
             .AddClass(Class)
             .Build();
 
-        [CascadingParameter] public bool RightToLeft { get; set; }
+        [CascadingParameter(Name = nameof(RightToLeft))] public bool RightToLeft { get; set; }
 
         [CascadingParameter] public TableContext Context { get; set; }
 

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -33,7 +33,7 @@ namespace MudBlazor
 
         private IResizeObserver _resizeObserver;
 
-        [CascadingParameter] public bool RightToLeft { get; set; }
+        [CascadingParameter(Name = nameof(RightToLeft))] public bool RightToLeft { get; set; }
 
         [Inject] private IResizeObserverFactory _resizeObserverFactory { get; set; }
 

--- a/src/MudBlazor/Components/Timeline/MudTimeline.razor.cs
+++ b/src/MudBlazor/Components/Timeline/MudTimeline.razor.cs
@@ -10,7 +10,7 @@ namespace MudBlazor
 {
     public partial class MudTimeline : MudBaseItemsControl<MudTimelineItem>
     {
-        [CascadingParameter] public bool RightToLeft { get; set; }
+        [CascadingParameter(Name = nameof(RightToLeft))] public bool RightToLeft { get; set; }
 
         /// <summary>
         /// Sets the orientation of the timeline and its timeline items.

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
@@ -31,7 +31,7 @@ namespace MudBlazor
         private Origin _anchorOrigin;
         private Origin _transformOrigin;
 
-        [CascadingParameter]
+        [CascadingParameter(Name = nameof(RightToLeft))]
         public bool RightToLeft { get; set; }
 
         /// <summary>

--- a/src/MudBlazor/Components/Typography/MudText.razor.cs
+++ b/src/MudBlazor/Components/Typography/MudText.razor.cs
@@ -26,7 +26,7 @@ namespace MudBlazor
             };
         }
 
-        [CascadingParameter] public bool RightToLeft { get; set; }
+        [CascadingParameter(Name = nameof(RightToLeft))] public bool RightToLeft { get; set; }
 
         /// <summary>
         /// Applies the theme typography styles.


### PR DESCRIPTION
Named the RightToLeft CascadingValue since it can interfere with user's code. See https://github.com/MudBlazor/MudBlazor/issues/4862
Modified Contribuiting.MD to correctly add the name parameter.

